### PR TITLE
14 multiple prescribed seed points can cause hangups in root setting v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ long_description = (here / "README.md").read_text("utf8")
 #VERSION = re.search(
 #    r'__version__ = "(.+?)"', (here / "svcco" / "__init__.py").read_text("utf8")
 #).group(1)
-VERSION = '0.6.21'
+VERSION = '0.6.24'
 
 CLASSIFIERS = ['Intended Audience :: Science/Research',
                'License :: OSI Approved :: MIT License',

--- a/svcco/__init__.py
+++ b/svcco/__init__.py
@@ -27,7 +27,7 @@ pip install svcco
 '''
 #from __future__ import annotations
 
-__version__ = "0.6.21"
+__version__ = "0.6.24"
 
 import traceback
 import warnings

--- a/svcco/branch_addition/set_root.py
+++ b/svcco/branch_addition/set_root.py
@@ -187,7 +187,9 @@ def set_root(data, boundary, Qterm, gamma, nu,
                                     cell_list = list(cell_list_outter.difference(cell_list_inner))
                                 ball_size *= 1.1
                         #p1,_ = boundary.pick(homogeneous=True)
-                        cell_id = cell_list.pop(0)
+                        cell_list_range = list(range(len(cell_list)))
+                        random_index = np.random.choice(cell_list_range)
+                        cell_id = cell_list.pop(random_index)
                         p1,_ = boundary.pick_in_cell(cell_id)
                         lengths = [np.linalg.norm(p1-p0)]
                         subdivisions = 8

--- a/svcco/forest_utils/compete_add.py
+++ b/svcco/forest_utils/compete_add.py
@@ -38,35 +38,24 @@ def compete_add(forest,network_ids=-1,radius_buffer=0.05,exact=True):
     #forest.boundary.volume = forest.boundary.volume/scale
     #networks_copy = deepcopy(forest.networks)
     #unused_networks = list(set(all_network_ids) - set(active_network_ids))
+    network_pbar = tqdm(total=len(active_network_ids),desc='Adding to networks',leave=False,position=1)
     while len(active_network_ids) > 0:
-        for ii, nid in enumerate(active_network_ids):
-            for njd in active_network_tree_ids[ii]:
-                repeat = True
-                while repeat:
-                    ## Preallocate points to check for new vessel appending
-                    while len(forest.networks[nid][njd].rng_points) <= 1:
-                        for idx in list(range(forest.number_of_networks)):
-                            for jdx in list(range(forest.trees_per_network[idx])):
-                                forest.networks[idx][jdx].rng_points = []
-                        rng_points,_ = forest.boundary.pick(size=min(len(forest.boundary.tet_verts),10000),homogeneous=True,replacement=False)
-                        rng_points = rng_points.tolist()
-                        for n in range(len(rng_points)):
-                            pt = np.array(rng_points.pop(0))
-                            closest_network  = None
-                            closest_distance = np.inf
-                            for idx in list(range(forest.number_of_networks)):
-                                for jdx in list(range(forest.trees_per_network[idx])):
-                                    if exact:
-                                        distances = close_exact_v2(forest.networks[idx][jdx].data,pt)
-                                    else:
-                                        _,distances = close(forest.networks[idx][jdx].data,pt)
-                                    if min(distances) < closest_distance:
-                                        closest_network = idx
-                                        closest_distance = min(distances)
-                            forest.networks[closest_network][np.random.choice(len(forest.networks[closest_network]))].rng_points.insert(-1,pt.tolist())
-                    start = perf_counter()
-                    for n in range(len(forest.networks[nid][njd].rng_points)):
-                        pt = np.array(forest.networks[nid][njd].rng_points.pop(0))
+        nid = active_network_ids[0]
+        tree_pbar = tqdm(total=len(active_network_tree_ids[nid]),desc='Adding to Network {} Trees'.format(nid),leave=False,position=2)
+        tree_pbar.refresh()
+        while len(active_network_tree_ids[nid]) > 0:
+            njd = active_network_tree_ids[nid][0]
+            repeat = True
+            while repeat:
+                ## Preallocate points to check for new vessel appending
+                while len(forest.networks[nid][njd].rng_points) <= 1:
+                    for idx in list(range(forest.number_of_networks)):
+                        for jdx in list(range(forest.trees_per_network[idx])):
+                            forest.networks[idx][jdx].rng_points = []
+                    rng_points,_ = forest.boundary.pick(size=min(len(forest.boundary.tet_verts),1000),homogeneous=True,replacement=False)
+                    rng_points = rng_points.tolist()
+                    for n in range(len(rng_points)):
+                        pt = np.array(rng_points.pop(0))
                         closest_network  = None
                         closest_distance = np.inf
                         for idx in list(range(forest.number_of_networks)):
@@ -79,81 +68,102 @@ def compete_add(forest,network_ids=-1,radius_buffer=0.05,exact=True):
                                     closest_network = idx
                                     closest_distance = min(distances)
                         forest.networks[closest_network][np.random.choice(len(forest.networks[closest_network]))].rng_points.insert(-1,pt.tolist())
-                    #print('End point reallocation: {}'.format(perf_counter()-start))
-                    ##
-                    #print(len(forest.networks[nid][njd].rng_points))
-                    #print("Check: {}".format(forest.networks[nid][njd].rng_points[0]))
-                    start = perf_counter()
-                    vessel,data,sub_division_map,sub_division_index,threshold = forest.networks[nid][njd].add(-1,0,isforest=True,radius_buffer=radius_buffer)
-                    #print('End vessel appending: {}'.format(perf_counter()-start))
-                    point = data[-2,3:6] #new terminal point
-                    #print(point)
-                    #closest_network = nid
-                    #_,closest_value = close_exact(forest.networks[nid][njd].data[vessel,:].reshape(1,forest.networks[nid][njd].data.shape[1]),point)
-                    #escape = False
-                    """
+                start = perf_counter()
+                for n in range(len(forest.networks[nid][njd].rng_points)):
+                    pt = np.array(forest.networks[nid][njd].rng_points.pop(0))
+                    closest_network  = None
+                    closest_distance = np.inf
                     for idx in list(range(forest.number_of_networks)):
                         for jdx in list(range(forest.trees_per_network[idx])):
-                            if idx == nid:
-                                continue
                             if exact:
-                                other_vessels,distances = close_exact(forest.networks[idx][jdx].data,point)
+                                distances = close_exact_v2(forest.networks[idx][jdx].data,pt)
                             else:
-                                other_vessels,distances = close(forest.networks[idx][jdx].data,point)
-                            minimum_distance = min(distances)
-                            minimum_vessel_point = (forest.networks[idx][jdx].data[other_vessels[0],0:3] + forest.networks[idx][jdx].data[other_vessels[0],3:6])/2
-                            if minimum_distance < closest_value:
-                                #print('other closer')
-                                vessel_within = True
-                                if not forest.convex:
-                                    subdivisions = 5
-                                    for sub in range(1,2*subdivisions):
-                                        tmp = point*(sub/(2*subdivisions)) + minimum_vessel_point*(1-sub/(2*subdivisions))
-                                        if not forest.boundary.within(tmp[0],tmp[1],tmp[2],2):
-                                            vessel_within = False
-                                            #print('not within')
-                                            break
-                                if not vessel_within:
-                                    continue
-                                else:
-                                    escape = True
-                                    break
-                        if escape:
-                            break
-                    """
-                    #if escape:
-                    #    #forest.networks[nid][njd] = deepcopy(networks_copy[nid][njd])
-                    #    continue
-                    start = perf_counter()
-                    new_vessels = np.vstack((data[vessel,:],data[-2,:],data[-1,:]))
-                    repeat = False
-                    #check_networks = unused_networks + [nid]
-                    check_networks = [nid]
-                    for nikd in check_networks:
-                        if nikd == nid:
-                            check_trees = list(range(len(forest.networks[nikd])))
-                            check_trees.remove(njd)
+                                _,distances = close(forest.networks[idx][jdx].data,pt)
+                            if min(distances) < closest_distance:
+                                closest_network = idx
+                                closest_distance = min(distances)
+                    forest.networks[closest_network][np.random.choice(len(forest.networks[closest_network]))].rng_points.insert(-1,pt.tolist())
+                #print('End point reallocation: {}'.format(perf_counter()-start))
+                ##
+                #print(len(forest.networks[nid][njd].rng_points))
+                #print("Check: {}".format(forest.networks[nid][njd].rng_points[0]))
+                start = perf_counter()
+                vessel,data,sub_division_map,sub_division_index,threshold = forest.networks[nid][njd].add(-1,0,isforest=True,radius_buffer=radius_buffer)
+                #print('End vessel appending: {}'.format(perf_counter()-start))
+                point = data[-2,3:6] #new terminal point
+                #print(point)
+                #closest_network = nid
+                #_,closest_value = close_exact(forest.networks[nid][njd].data[vessel,:].reshape(1,forest.networks[nid][njd].data.shape[1]),point)
+                #escape = False
+                """
+                for idx in list(range(forest.number_of_networks)):
+                    for jdx in list(range(forest.trees_per_network[idx])):
+                        if idx == nid:
+                            continue
+                        if exact:
+                            other_vessels,distances = close_exact(forest.networks[idx][jdx].data,point)
                         else:
-                            check_trees = list(range(len(forest.networks[nikd])))
-                        for njkd in check_trees:
-                            if not forest.networks[nikd][njkd].collision_free(new_vessels,radius_buffer=radius_buffer):
-                                repeat = True
+                            other_vessels,distances = close(forest.networks[idx][jdx].data,point)
+                        minimum_distance = min(distances)
+                        minimum_vessel_point = (forest.networks[idx][jdx].data[other_vessels[0],0:3] + forest.networks[idx][jdx].data[other_vessels[0],3:6])/2
+                        if minimum_distance < closest_value:
+                            #print('other closer')
+                            vessel_within = True
+                            if not forest.convex:
+                                subdivisions = 5
+                                for sub in range(1,2*subdivisions):
+                                    tmp = point*(sub/(2*subdivisions)) + minimum_vessel_point*(1-sub/(2*subdivisions))
+                                    if not forest.boundary.within(tmp[0],tmp[1],tmp[2],2):
+                                        vessel_within = False
+                                        #print('not within')
+                                        break
+                            if not vessel_within:
+                                continue
+                            else:
+                                escape = True
                                 break
-                        if repeat:
-                            break
-                    #print('End collision testing: {}'.format(perf_counter()-start))
-                    if repeat:
-                        #print('repeating')
-                        #forest.networks[nid][njd] = deepcopy(networks_copy[nid][njd])
-                        continue
+                    if escape:
+                        break
+                """
+                #if escape:
+                #    #forest.networks[nid][njd] = deepcopy(networks_copy[nid][njd])
+                #    continue
+                start = perf_counter()
+                new_vessels = np.vstack((data[vessel,:],data[-2,:],data[-1,:]))
+                repeat = False
+                #check_networks = unused_networks + [nid]
+                check_networks = [nid]
+                for nikd in check_networks:
+                    if nikd == nid:
+                        check_trees = list(range(len(forest.networks[nikd])))
+                        check_trees.remove(njd)
                     else:
-                        forest.networks[nid][njd].data = data
-                        forest.networks[nid][njd].parameters['edge_num'] += 2
-                        forest.networks[nid][njd].sub_division_map = sub_division_map
-                        forest.networks[nid][njd].sub_division_index = sub_division_index
-                        #print("List {}: {},  Id: {}".format(nid,active_network_tree_ids[nid],njd))
-                        active_network_tree_ids[ii].remove(njd)
-                        if len(active_network_tree_ids[ii]) == 0:
-                            active_network_ids.remove(nid)
-                        #print("Active Networks: {}".format(active_network_ids))
+                        check_trees = list(range(len(forest.networks[nikd])))
+                    for njkd in check_trees:
+                        if not forest.networks[nikd][njkd].collision_free(new_vessels,radius_buffer=radius_buffer):
+                            repeat = True
+                            break
+                    if repeat:
+                        break
+                #print('End collision testing: {}'.format(perf_counter()-start))
+                if repeat:
+                    #print("Repeating Network {} Tree {}".format(nid,njd))
+                    #forest.networks[nid][njd] = deepcopy(networks_copy[nid][njd])
+                    continue
+                else:
+                    forest.networks[nid][njd].data = data
+                    forest.networks[nid][njd].parameters['edge_num'] += 2
+                    forest.networks[nid][njd].sub_division_map = sub_division_map
+                    forest.networks[nid][njd].sub_division_index = sub_division_index
+                    #network_index = active_network_ids.index(nid)
+                    #print("List {}: {},  Id: {}".format(nid,active_network_tree_ids[nid],njd))
+                    active_network_tree_ids[nid].remove(njd)
+                    tree_pbar.update(1)
+                    _ = tree_pbar.refresh()
+                    if len(active_network_tree_ids[nid]) == 0:
+                        active_network_ids.remove(nid)
+                        network_pbar.update(1)
+                        _ = network_pbar.refresh()
+                    #print("Active Networks: {}".format(active_network_ids))
+                    #print("Completed Network {} Tree {}".format(nid,njd))
     forest.boundary.volume = volume

--- a/svcco/tree.py
+++ b/svcco/tree.py
@@ -1709,7 +1709,7 @@ class forest:
                 networks[idx].append(None)
                 total_trees += 1
         # enter main loop for root setting
-        pbar = tqdm(total=total_trees)
+        pbar = tqdm(total=total_trees,desc='Setting Roots')
         current_progress = 0
         while len(root_queue) > 0:
             idx,jdx  = root_queue.pop(0)
@@ -1764,7 +1764,7 @@ class forest:
         self.connections = connections
         self.backup      = backup
         if self.compete:
-            self.boundary.volume = volume
+            self.boundary.volume = volume/self.number_of_networks
 
     def add(self,number_of_branches,network_id=0,radius_buffer=0.01,exact=True):
         """
@@ -1883,7 +1883,7 @@ class forest:
                     if self.networks[nid][0].parameters['edge_num'] >= exit_number[nid]:
                         active_networks.remove(nid)
         else:
-            for i in tqdm(range(number_of_branches),desc="Adding branches"):
+            for i in tqdm(range(number_of_branches),desc="Adding branches",leave=True,position=0):
                 compete_add(self,network_ids=network_id,radius_buffer=radius_buffer)
 
     def show(self,show=True,resolution=100,final=False,merged_trees=False,background='white',off_screen=False):

--- a/svcco/tree.py
+++ b/svcco/tree.py
@@ -1671,7 +1671,8 @@ class forest:
             networks.append(network)
         self.networks    = networks
 
-    def set_roots(self,scale=None,bounds=None):
+    def set_roots(self,scale=None,bounds=None,number_of_consecutive_collisions=5,
+                  minimum_distance=None):
         """
         Set the root vessels of each tree within each network of the vascular
         forest object
@@ -1696,52 +1697,69 @@ class forest:
         networks = []
         connections = []
         backup = []
+        # create an ordered list of network and tree tuples to proceed with
+        root_queue = []
+        total_trees = 0
         for idx in range(self.number_of_networks):
-            network = []
-            if not isinstance(self.trees_per_network,list):
-                print("trees_per_network must be list of ints"+
-                      " with length equal to number_of_networks")
-            for jdx in range(self.trees_per_network[idx]):
-                #tmp = tree()
-                tmp = self.networks[idx][jdx]
-                #tmp.set_assumptions(convex=self.convex)
-                #if self.directions[idx][jdx] is not None:
-                #    tmp.clamped_root = True
-                #tmp.set_boundary(self.boundary)
-                if scale is not None:
-                    tmp.parameters['Qterm'] *= scale
-                if idx == 0 and jdx == 0:
-                    collisions = [True]
-                else:
-                    collisions = [True]
-                while any(collisions):
-                    if bounds is None:
-                        tmp.set_root(start=self.starting_points[idx][jdx],
-                                     direction=self.directions[idx][jdx],
-                                     limit_high=self.root_lengths_high[idx][jdx],
-                                     limit_low=self.root_lengths_low[idx][jdx])
-                    else:
-                        print("Not implemented yet!")
-                    collisions = []
-                    repeat = False
-                    for net in networks:
-                        for t in net:
-                            collisions.append(not t.collision_free(tmp.data[0,:].reshape(1,-1)))
-                            if collisions[-1]:
-                                repeat = True
-                                break
-                        if repeat:
-                            break
-                    for t in network:
-                        collisions.append(not t.collision_free(tmp.data[0,:].reshape(1,-1)))
-                        if collisions[-1]:
-                            repeat = True
-                            break
-                    #print(collisions)
-                network.append(tmp)
-            networks.append(network)
+            networks.append([])
             connections.append(None)
             backup.append(None)
+            for jdx in range(self.trees_per_network[idx]):
+                root_queue.append(tuple([idx,jdx]))
+                networks[idx].append(None)
+                total_trees += 1
+        # enter main loop for root setting
+        pbar = tqdm(total=total_trees)
+        current_progress = 0
+        while len(root_queue) > 0:
+            idx,jdx  = root_queue.pop(0)
+            tmp_tree = self.networks[idx][jdx]
+            collisions = [True] # True to start the collision checking loop
+            last_collision = {}
+            #print(current_progress)
+            while any(collisions):
+                tmp_tree.set_root(start=self.starting_points[idx][jdx],
+                                  direction=self.directions[idx][jdx],
+                                  limit_high=self.root_lengths_high[idx][jdx],
+                                  limit_low=self.root_lengths_low[idx][jdx])
+                collisions = []
+                repeat     = False
+                for ndx in range(self.number_of_networks):
+                    for tdx in range(self.trees_per_network[ndx]):
+                        if ndx == idx and jdx == tdx:
+                            collisions.append(False)
+                            continue
+                        if not networks[ndx][tdx] is None:
+                            collisions.append(not networks[ndx][tdx].collision_free(tmp_tree.data[0,:].reshape(1,-1)))
+                        else:
+                            collisions.append(False)
+                        if collisions[-1]:
+                            repeat = True
+                            if (ndx,tdx) in last_collision.keys():
+                                last_collision[(ndx,tdx)] += 1
+                            else:
+                                last_collision[(ndx,tdx)] = 1
+                            break
+                    if repeat:
+                       break
+                if repeat:
+                    collision_values = list(last_collision.values())
+                    if any(val == number_of_consecutive_collisions for val in collision_values):
+                        key_index = collision_values.index(number_of_consecutive_collisions)
+                        key = list(last_collision.keys())[key_index]
+                        networks[key[0]][key[1]] = None
+                        root_queue.insert(0,(idx,jdx))
+                        root_queue.insert(0,key)
+                        current_progress -= 1
+                        pbar.reset()
+                        pbar.update(current_progress)
+                        _ = pbar.refresh()
+                        break
+                else:
+                    networks[idx][jdx] = tmp_tree
+                    current_progress += 1
+                    pbar.update(1)
+                    _ = pbar.refresh()
         self.networks    = networks
         self.connections = connections
         self.backup      = backup


### PR DESCRIPTION
Changes to code:

- during root setting for `forest` objects. conflicting roots are culled and reinitialized to prevent stalling
- in nonconvex shapes during root setting cell elements are randomly picked to prevent repeated bad selection of conflicting geometries
- during competitive growth of  `forest`  objects networks display multi-level progress bars by default